### PR TITLE
hostconfig: add MetadataPort()

### DIFF
--- a/pkg/agent/utils/flowsource.go
+++ b/pkg/agent/utils/flowsource.go
@@ -58,7 +58,7 @@ func (h *HostLocal) FlowsMap() (map[string][]*ovs.Flow, error) {
 		return nil, err
 	}
 	m := map[string]interface{}{
-		"MetadataPort": h.HostConfig.Port,
+		"MetadataPort": h.HostConfig.MetadataPort(),
 		"K8SCidr":      h.HostConfig.K8sClusterCidr,
 		"IP":           h.IP,
 		"MAC":          h.MAC,
@@ -119,7 +119,7 @@ func (g *Guest) FlowsMap() (map[string][]*ovs.Flow, error) {
 		}
 		portNoPhy := ps.PortID
 		m := nic.Map()
-		m["MetadataPort"] = g.HostConfig.Port
+		m["MetadataPort"] = g.HostConfig.MetadataPort()
 		m["PortNoPhy"] = portNoPhy
 		T := t(m)
 		if nic.VLAN > 1 {

--- a/pkg/agent/utils/hostconfig.go
+++ b/pkg/agent/utils/hostconfig.go
@@ -38,6 +38,10 @@ type HostConfig struct {
 	AllowSwitchVMs bool // allow virtual machines act as switches
 }
 
+func (hc *HostConfig) MetadataPort() int {
+	return hc.Port + 1000
+}
+
 var snippet_pre = []byte(`
 from __future__ import print_function
 port = None


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

将metadata server的端口指定为host server监听端口+1000

**是否需要 backport 到之前的 release 分支**:

- release/2.6.0