### PR TITLE
fix: remove ovs kmod dependency so as to deploy on centos 6

### DIFF
--- a/build/sdnagent/vars
+++ b/build/sdnagent/vars
@@ -1,5 +1,1 @@
 DESCRIPTION="Yunion Cloud SDN Agent Service"
-
-REQUIRES=(
-	"kmod-openvswitch >= 2.8.2"
-)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
centos 6无法编译出ovs kmod。取消对ovs kmod的依赖，这样才能部署在centos 6主机上。

**是否需要 backport 到之前的 release 分支**:
- release/2.8.0
- release/2.7.0
- release/2.6.0