### PR TITLE
tcman: qdisc del before replace

### DIFF
--- a/pkg/agent/server/tcman.go
+++ b/pkg/agent/server/tcman.go
@@ -19,7 +19,8 @@ type TcManPage struct {
 }
 
 func (p *TcManPage) batchReplaceInput() string {
-	lines := p.qtWant.BatchReplaceLines(p.ifname)
+	lines := []string{"qdisc del dev " + p.ifname + " root"}
+	lines = append(lines, p.qtWant.BatchReplaceLines(p.ifname)...)
 	lines = append(lines, "qdisc show dev "+p.ifname)
 	input := strings.Join(lines, "\n")
 	// NOTE final newline is needed to workaround buffer overflow issues in


### PR DESCRIPTION

**这个 PR 实现什么功能/修复什么问题**:

"tc xx replace" does not support changing kind

	1488                                 if (tca[TCA_KIND] &&
	1489                                     nla_strcmp(tca[TCA_KIND], q->ops->id)) {
	1490                                         NL_SET_ERR_MSG(extack, "Invalid qdisc name");
	1491                                         return -EINVAL;
	1492                                 }


**是否需要 backport 到之前的 release 分支**:

- release/2.6.0
