### PR TITLE
Automated cherry pick of #36: flowsource: 允许dhcp服务器监听在非67号端口

### DIFF
--- a/pkg/agent/utils/flowsource.go
+++ b/pkg/agent/utils/flowsource.go
@@ -121,6 +121,7 @@ func (g *Guest) FlowsMap() (map[string][]*ovs.Flow, error) {
 		portNoPhy := ps.PortID
 		m := nic.Map()
 		m["MetadataPort"] = g.HostConfig.MetadataPort()
+		m["DHCPServerPort"] = g.HostConfig.DHCPServerPort
 		m["PortNoPhy"] = portNoPhy
 		T := t(m)
 		if nic.VLAN > 1 {
@@ -140,8 +141,8 @@ func (g *Guest) FlowsMap() (map[string][]*ovs.Flow, error) {
 			F(0, 29200,
 				T("in_port=LOCAL,tcp,nw_dst={{.IP}},tp_src={{.MetadataPort}}"),
 				T("mod_dl_dst:{{.MAC}},mod_nw_src:169.254.169.254,mod_tp_src:80,output:{{.PortNo}}")),
-			F(0, 28400, T("in_port={{.PortNo}},udp,tp_src=68,tp_dst=67"), "local"),
-			F(0, 28300, T("in_port=LOCAL,dl_dst={{.MAC}},udp,tp_src=67,tp_dst=68"), T("output:{{.PortNo}}")),
+			F(0, 28400, T("in_port={{.PortNo}},udp,tp_src=68,tp_dst=67"), T("mod_tp_dst:{{.DHCPServerPort}},local")),
+			F(0, 28300, T("in_port=LOCAL,dl_dst={{.MAC}},udp,tp_src={{.DHCPServerPort}},tp_dst=68"), T("mod_tp_src:67,output:{{.PortNo}}")),
 			F(0, 26700, T("in_port={{.PortNoPhy}},dl_dst={{.MAC}},{{._dl_vlan}}"), "normal"),
 		)
 		if g.HostConfig.AllowSwitchVMs {

--- a/pkg/agent/utils/hostconfig.go
+++ b/pkg/agent/utils/hostconfig.go
@@ -36,6 +36,7 @@ type HostConfig struct {
 	ServersPath    string
 	K8sClusterCidr *net.IPNet
 	AllowSwitchVMs bool // allow virtual machines act as switches
+	DHCPServerPort int
 }
 
 func (hc *HostConfig) MetadataPort() int {
@@ -50,6 +51,7 @@ networks = []
 servers_path = "/opt/cloud/workspace/servers"
 k8s_cluster_cidr = '10.43.0.0/16'
 allow_switch_vms = False
+dhcp_server_port = 67
 
 `)
 var snippet_post = []byte(`
@@ -62,6 +64,7 @@ print(json.dumps({
 	'servers_path': servers_path,
 	'k8s_cluster_cidr': k8s_cluster_cidr,
 	'allow_switch_vms': bool(allow_switch_vms),
+	'dhcp_server_port': dhcp_server_port,
 }))
 `)
 
@@ -103,6 +106,7 @@ func newHostConfigFromBytes(data []byte) (*HostConfig, error) {
 		ServersPath    string `json:"servers_path"`
 		K8sClusterCidr string `json:"k8s_cluster_cidr"`
 		AllowSwitchVMs bool   `json:"allow_switch_vms"`
+		DHCPServerPort int    `json:"dhcp_server_port"`
 	}{}
 	err = json.Unmarshal(jstr, &v)
 	if err != nil {
@@ -113,6 +117,7 @@ func newHostConfigFromBytes(data []byte) (*HostConfig, error) {
 		Port:           v.Port,
 		ServersPath:    v.ServersPath,
 		AllowSwitchVMs: v.AllowSwitchVMs,
+		DHCPServerPort: v.DHCPServerPort,
 	}
 	_, k8sCidr, err := net.ParseCIDR(v.K8sClusterCidr)
 	if err == nil {

--- a/pkg/agent/utils/hostconfig_test.go
+++ b/pkg/agent/utils/hostconfig_test.go
@@ -28,6 +28,7 @@ func TestHostConfig(t *testing.T) {
 				Port:           0,
 				ServersPath:    "/opt/cloud/workspace/servers",
 				K8sClusterCidr: defaultK8sCidr,
+				DHCPServerPort: 67,
 			},
 		},
 		{
@@ -37,6 +38,7 @@ servers_path = '/opt/cloud/workspace/servers_owl'
 networks = ['eth0/br0/10.168.222.136']
 k8s_cluster_cidr = '10.44.0.0/17'
 allow_switch_vms = True
+dhcp_server_port = 1067
 			`,
 			want: &HostConfig{
 				Port: 8885,
@@ -50,6 +52,7 @@ allow_switch_vms = True
 				ServersPath:    "/opt/cloud/workspace/servers_owl",
 				K8sClusterCidr: nonDefaultK8sCidr,
 				AllowSwitchVMs: true,
+				DHCPServerPort: 1067,
 			},
 		},
 	}


### PR DESCRIPTION
Cherry pick of #36 on release/2.9.0.

#36: flowsource: 允许dhcp服务器监听在非67号端口