### PR TITLE
Automated cherry pick of #53: hostconfig: also fill hcn.IP besides hcn.mac

### DIFF
--- a/pkg/agent/utils/hostconfig.go
+++ b/pkg/agent/utils/hostconfig.go
@@ -36,6 +36,19 @@ func (hcn *HostConfigNetwork) IPMAC() (net.IP, net.HardwareAddr, error) {
 		if err != nil {
 			return nil, nil, err
 		}
+		addrs, err := iface.Addrs()
+		if err != nil {
+			return nil, nil, err
+		}
+		for _, addr := range addrs {
+			if ipnet, ok := addr.(*net.IPNet); ok {
+				ip := ipnet.IP.To4()
+				if ip != nil {
+					hcn.IP = ip
+					break
+				}
+			}
+		}
 		hcn.mac = iface.HardwareAddr
 	}
 	if hcn.IP != nil && hcn.mac != nil {


### PR DESCRIPTION
Cherry pick of #53 on release/2.11.

#53: hostconfig: also fill hcn.IP besides hcn.mac