### PR TITLE
Separate CheckIP, CheckMac knobs for each guest

### DIFF
--- a/pkg/agent/utils/hostconfig.go
+++ b/pkg/agent/utils/hostconfig.go
@@ -105,7 +105,7 @@ networks = []
 servers_path = "/opt/cloud/workspace/servers"
 k8s_cluster_cidr = '10.43.0.0/16'
 allow_switch_vms = False
-allow_router_vms = False
+allow_router_vms = True
 dhcp_server_port = 67
 
 `)
@@ -150,6 +150,7 @@ func newHostConfigFromBytes(data []byte) (*HostConfig, error) {
 		ServersPath:    "/opt/cloud/workspace/servers",
 		K8sClusterCidr: "10.43.0.0/16",
 		DHCPServerPort: 67,
+		AllowRouterVMs: true,
 	}
 	{
 		type funcType func([]byte, interface{}) error

--- a/pkg/agent/utils/hostconfig_test.go
+++ b/pkg/agent/utils/hostconfig_test.go
@@ -46,6 +46,7 @@ func TestHostConfig(t *testing.T) {
 				ServersPath:    "/opt/cloud/workspace/servers",
 				K8sClusterCidr: defaultK8sCidr,
 				DHCPServerPort: 67,
+				AllowRouterVMs: true,
 			},
 		},
 		{


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

```
This changes semantics of host.conf allow_switch_vms, allow_router_vms.

Previously these are host-wide knobs for all guests on that specific
host.  Now they serve as prerequisites for hosting switch, router
guests.

AllowRouterVMs but keep AllowSwitchVMs=false by default.  The latter one
can cause packet leak because of flood while the former one won't
```

**是否需要 backport 到之前的 release 分支**:

- release/2.13

/cc @ioito @swordqiu 
/cc @wanyaoqi 