### PR TITLE
Bugfix/yousong critical watcher

### DIFF
--- a/pkg/agent/server/server.go
+++ b/pkg/agent/server/server.go
@@ -46,8 +46,8 @@ func (s *AgentServer) GetFlowMan(bridge string) *FlowMan {
 	}
 	flowman := NewFlowMan(bridge)
 	theAgentServer.flowMans[bridge] = flowman
-	go flowman.Start(s.ctx)
 	s.wg.Add(1)
+	go flowman.Start(s.ctx)
 	return flowman
 }
 
@@ -57,10 +57,11 @@ func (s *AgentServer) Start() error {
 		log.Fatalf("listen %s failed: %s", common.UnixSocketFile, err)
 	}
 	defer lis.Close()
+
 	defer s.wg.Wait()
+	s.wg.Add(2)
 	go s.serversWatcher.Start(s.ctx, s)
 	go s.ifaceJanitor.Start(s.ctx)
-	s.wg.Add(2)
 	err = s.rpcServer.Serve(lis)
 	return err
 }

--- a/pkg/agent/server/watch.go
+++ b/pkg/agent/server/watch.go
@@ -130,6 +130,8 @@ func (w *serversWatcher) hasRecentPending() bool {
 }
 
 func (w *serversWatcher) Start(ctx context.Context, agent *AgentServer) {
+	defer agent.Stop()
+
 	// workgroup
 	wg := ctx.Value("wg").(*sync.WaitGroup)
 	defer wg.Done()
@@ -153,7 +155,7 @@ func (w *serversWatcher) Start(ctx context.Context, agent *AgentServer) {
 	defer w.watcher.Close()
 	err = w.watcher.Add(w.hostConfig.ServersPath)
 	if err != nil {
-		log.Errorf("wathcing %s failed: %s", w.hostConfig.ServersPath, err)
+		log.Errorf("watching %s failed: %s", w.hostConfig.ServersPath, err)
 		return
 	}
 

--- a/pkg/agent/server/watch.go
+++ b/pkg/agent/server/watch.go
@@ -157,8 +157,8 @@ func (w *serversWatcher) Start(ctx context.Context, agent *AgentServer) {
 		return
 	}
 
-	go w.tcMan.Start(ctx)
 	wg.Add(1)
+	go w.tcMan.Start(ctx)
 
 	// init scan
 	w.hostLocal = NewHostLocal(w)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

```
treewide: fix waitgropu usage again …
server: stop with sync.Once
server: stop agent on watcher stop
```

**是否需要 backport 到之前的 release 分支**:

- release/2.10.0

/cc @zexi @swordqiu 