### PR TITLE
Automated cherry pick of #75: build: set _output/alpine-build owner to current user:group

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ docker-image:
 		-v $(CURDIR):/root/go/src/yunion.io/x/sdnagent \
 		-v $(CURDIR)/_output/alpine-build:/root/go/src/yunion.io/x/sdnagent/_output \
 		registry.cn-beijing.aliyuncs.com/yunionio/alpine-build:1.0-1 \
-		/bin/sh -c "set -ex; cd /root/go/src/yunion.io/x/sdnagent; make"
+		/bin/sh -c "set -ex; cd /root/go/src/yunion.io/x/sdnagent; make; chown -R $$(id -u):$$(id -g) _output"
 	docker build -t $(IMAGE_NAME_TAG) -f $(CURDIR)/build/docker/Dockerfile $(CURDIR)
 
 docker-image-push:


### PR DESCRIPTION
Cherry pick of #75 on release/3.1.

#75: build: set _output/alpine-build owner to current user:group