### PR TITLE
Automated cherry pick of #79: build: docker: add python2 dependency

### DIFF
--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM registry.cn-beijing.aliyuncs.com/yunionio/openvswitch:2.9.6-1
 
 MAINTAINER "Yousong Zhou <zhouyousong@yunion.cn>"
 
-RUN apk add iproute2
+RUN apk add iproute2 python2
 RUN mkdir -p /opt/yunion/bin
 ADD ./_output/alpine-build/bin/sdnagent /opt/yunion/bin/sdnagent
 ADD ./_output/alpine-build/bin/sdncli /opt/yunion/bin/sdncli


### PR DESCRIPTION
Cherry pick of #79 on release/3.1.

#79: build: docker: add python2 dependency