### PR TITLE
Automated cherry pick of #81: hostconfig: default allow_switch_vms to true

### DIFF
--- a/pkg/agent/utils/hostconfig.go
+++ b/pkg/agent/utils/hostconfig.go
@@ -176,6 +176,7 @@ func newHostConfigFromBytes(data []byte) (*HostConfig, error) {
 		ServersPath:    "/opt/cloud/workspace/servers",
 		K8sClusterCidr: "10.43.0.0/16",
 		DHCPServerPort: 67,
+		AllowSwitchVMs: true,
 		AllowRouterVMs: true,
 
 		OvnIntegrationBridge: "brvpc",


### PR DESCRIPTION
Cherry pick of #81 on release/3.1.

#81: hostconfig: default allow_switch_vms to true