### PR TITLE
hostconfig: default true allow_switch_vms for py config

### DIFF
--- a/pkg/agent/utils/hostconfig.go
+++ b/pkg/agent/utils/hostconfig.go
@@ -124,7 +124,7 @@ listen_interface = None
 networks = []
 servers_path = "/opt/cloud/workspace/servers"
 k8s_cluster_cidr = '10.43.0.0/16'
-allow_switch_vms = False
+allow_switch_vms = True
 allow_router_vms = True
 dhcp_server_port = 67
 

--- a/pkg/agent/utils/hostconfig_test.go
+++ b/pkg/agent/utils/hostconfig_test.go
@@ -46,6 +46,7 @@ func TestHostConfig(t *testing.T) {
 				ServersPath:          "/opt/cloud/workspace/servers",
 				K8sClusterCidr:       defaultK8sCidr,
 				DHCPServerPort:       67,
+				AllowSwitchVMs:       true,
 				AllowRouterVMs:       true,
 				OvnIntegrationBridge: "brvpc",
 			},


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

```
hostconfig: default true allow_switch_vms for py config
```

**是否需要 backport 到之前的 release 分支**:

- release/3.1

/cc @swordqiu 