### PR TITLE
Automated cherry pick of #96: agent: ovn: no error log if the mapped bridge does not exist

### DIFF
--- a/pkg/agent/server/ovn.go
+++ b/pkg/agent/server/ovn.go
@@ -364,6 +364,20 @@ func (man *ovnMan) cleanup(ctx context.Context) {
 
 	listPorts := func(br string) (map[string]utils.Empty, bool) {
 		cli := ovs.New().VSwitch
+		if brs, err := cli.ListBridges(); err != nil {
+			log.Errorf("list bridges: %v", err)
+			return nil, false
+		} else {
+			found := false
+			for _, got := range brs {
+				if got == br {
+					found = true
+				}
+			}
+			if !found {
+				return nil, true
+			}
+		}
 		ports, err := cli.ListPorts(br)
 		if err != nil {
 			log.Errorf("list bridge ports: %s: %v", br, err)


### PR DESCRIPTION
Cherry pick of #96 on release/3.2.

#96: agent: ovn: no error log if the mapped bridge does not exist