### PR TITLE
fix: eipgw should use separate sdn_socket_path

### DIFF
--- a/build/sdnagent/root/usr/share/sdnagent/ansible/templates/sdnagent.conf.j2
+++ b/build/sdnagent/root/usr/share/sdnagent/ansible/templates/sdnagent.conf.j2
@@ -8,5 +8,8 @@ session_endpoint_type = 'public'
 log_level = debug
 
 sdn_pid_file = '/var/run/yunion-sdnagent-eipgw.pid'
+sdn_socket_path = '/var/run/yunion-sdnagent-eipgw.sock'
 sdn_enable_guest_man = false
 sdn_enable_eip_man = true
+
+ovn_underlay_mtu = 1500


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：eipgw的sdnagent.conf需要明确独立的 sdn_socket_path

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/3.9
- release/3.8
- release/3.7

/cc @zexi 