### PR TITLE
Automated cherry pick of #204: fix: eipgw should use separate sdn_socket_path

### DIFF
--- a/build/sdnagent/root/usr/share/sdnagent/ansible/templates/sdnagent.conf.j2
+++ b/build/sdnagent/root/usr/share/sdnagent/ansible/templates/sdnagent.conf.j2
@@ -8,5 +8,8 @@ session_endpoint_type = 'public'
 log_level = debug
 
 sdn_pid_file = '/var/run/yunion-sdnagent-eipgw.pid'
+sdn_socket_path = '/var/run/yunion-sdnagent-eipgw.sock'
 sdn_enable_guest_man = false
 sdn_enable_eip_man = true
+
+ovn_underlay_mtu = 1500


### PR DESCRIPTION
Cherry pick of #204 on release/3.9.

#204: fix: eipgw should use separate sdn_socket_path