### PR TITLE
fix: fail to add physical nics to tap bridge

### DIFF
--- a/pkg/agent/server/tap.go
+++ b/pkg/agent/server/tap.go
@@ -322,7 +322,7 @@ func (s *sTapService) portsArgs(cli *ovs.VSwitchService, tapBridge string) [][]s
 		}
 		args := []string{
 			"ovs-vsctl",
-			"--", "--may-exist", "add-br", tapBridge, s.Ifname,
+			"--", "--may-exist", "add-port", tapBridge, s.Ifname,
 		}
 		ret = append(ret, args)
 	}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
fix: fail to add physical nics to tap bridge 

**是否需要 backport 到之前的 release 分支**:
- release/3.9

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
/cc @zexi @wanyaoqi 