### PR TITLE
fix: guest isSlave status inconsistent on 3.10

### DIFF
--- a/pkg/agent/utils/guest.go
+++ b/pkg/agent/utils/guest.go
@@ -32,6 +32,7 @@ type guestDesc struct {
 	Name               string
 
 	IsMaster bool   `json:"is_master"`
+	IsSlave  bool   `json:"is_slave"`
 	HostId   string `json:"host_id"`
 
 	SrcIpCheck  bool `json:"src_ip_check"`
@@ -40,7 +41,8 @@ type guestDesc struct {
 
 func newGuestDesc() *guestDesc {
 	desc := &guestDesc{
-		IsMaster:    true,
+		IsMaster:    false,
+		IsSlave:     false,
 		SrcIpCheck:  true,
 		SrcMacCheck: true,
 	}
@@ -232,7 +234,11 @@ func (g *Guest) LoadDesc() error {
 			g.NICs = append(g.NICs[:i], g.NICs[i+1:]...)
 		}
 	}
-	g.isSlave = !desc.IsMaster
+	if !desc.IsMaster && desc.IsSlave {
+		g.isSlave = true
+	} else {
+		g.isSlave = false
+	}
 
 	g.srcIpCheck = desc.SrcIpCheck
 	g.srcMacCheck = desc.SrcMacCheck


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
fix: guest is_slave status inconsistent on 3.10

**是否需要 backport 到之前的 release 分支**:
NONE
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
/cc @wanyaoqi @zexi 