### PR TITLE
fix: sdnagent fatal on dump-flow error

### DIFF
--- a/pkg/agent/server/flowman.go
+++ b/pkg/agent/server/flowman.go
@@ -61,7 +61,7 @@ func (fm *FlowMan) doDumpFlows() (*utils.FlowSet, error) {
 	ofCli := ovs.New().OpenFlow
 	flows, err := ofCli.DumpFlows(fm.bridge)
 	if err != nil {
-		log.Errorf("flowman %s: dump-flows failed: %s", fm.bridge, err)
+		log.Fatalf("flowman %s: dump-flows failed: %s", fm.bridge, err)
 		return nil, err
 	}
 	for _, of := range flows {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
sdnagent遇到ovs错误时fatal退出

**是否需要 backport 到之前的 release 分支**:
- release/3.9
- release/3.8

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
/cc @zexi @wanyaoqi 