### PR TITLE
fix: fatal if no ovsdb db.sock exists

### DIFF
--- a/pkg/agent/server/flowman.go
+++ b/pkg/agent/server/flowman.go
@@ -26,6 +26,9 @@ import (
 	"github.com/digitalocean/go-openvswitch/ovs"
 
 	"yunion.io/x/log"
+	"yunion.io/x/pkg/errors"
+
+	"yunion.io/x/onecloud/pkg/util/fileutils2"
 
 	"yunion.io/x/sdnagent/pkg/agent/utils"
 )
@@ -58,11 +61,16 @@ type FlowMan struct {
 }
 
 func (fm *FlowMan) doDumpFlows() (*utils.FlowSet, error) {
+	// check existence of ovs-db's sock file
+	const ovsDbSock = "/var/run/openvswitch/db.sock"
+	if !fileutils2.Exists(ovsDbSock) {
+		log.Fatalf("%s not exists!", ovsDbSock)
+	}
 	ofCli := ovs.New().OpenFlow
 	flows, err := ofCli.DumpFlows(fm.bridge)
 	if err != nil {
-		log.Fatalf("flowman %s: dump-flows failed: %s", fm.bridge, err)
-		return nil, err
+		log.Errorf("flowman %s: dump-flows failed: %s", fm.bridge, err)
+		return nil, errors.Wrap(err, "DumpFlows")
 	}
 	for _, of := range flows {
 		utils.OVSFlowOrderMatch(of)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
fix: fatal if no ovsdb db.sock exists

**是否需要 backport 到之前的 release 分支**:
- release/3.9
- release/3.8

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->

/cc @zexi 
