### PR TITLE
add check is volatile host

### DIFF
--- a/pkg/agent/server/guest.go
+++ b/pkg/agent/server/guest.go
@@ -31,7 +31,7 @@ import (
 var (
 	errNotRunning   = fmt.Errorf("not running")
 	errPortNotReady = fmt.Errorf("port not ready") // no port is ready
-	errSlaveMachine = fmt.Errorf("slave machine")
+	errVolatileHost = fmt.Errorf("volatile host")
 )
 
 type Guest struct {
@@ -147,8 +147,8 @@ func (g *Guest) refresh(ctx context.Context) (err error) {
 	if err != nil {
 		return
 	}
-	if g.IsSlave() {
-		err = errSlaveMachine
+	if g.IsVolatileHost() {
+		err = errVolatileHost
 		setPending = false
 		return
 	}
@@ -240,7 +240,7 @@ func (g *Guest) UpdateSettings(ctx context.Context) {
 		if g.HostId != "" {
 			g.watcher.agent.HostId(g.HostId)
 		}
-	case errNotRunning, errPortNotReady, errSlaveMachine:
+	case errNotRunning, errPortNotReady, errVolatileHost:
 		g.ClearSettings(ctx)
 	}
 }

--- a/pkg/agent/utils/guest.go
+++ b/pkg/agent/utils/guest.go
@@ -37,6 +37,7 @@ type guestDesc struct {
 	IsMaster bool   `json:"is_master"`
 	IsSlave  bool   `json:"is_slave"`
 	HostId   string `json:"host_id"`
+	IsVolatileHost bool `json:"is_volatile_host"`
 
 	SrcIpCheck  bool `json:"src_ip_check"`
 	SrcMacCheck bool `json:"src_mac_check"`
@@ -154,6 +155,7 @@ type Guest struct {
 	srcMacCheck bool
 
 	isSlave bool
+	isVolatileHost bool
 }
 
 func (g *Guest) IsVM() bool {
@@ -195,8 +197,8 @@ func (g *Guest) Running() bool {
 	return false
 }
 
-func (g *Guest) IsSlave() bool {
-	return g.isSlave
+func (g *Guest) IsVolatileHost() bool {
+	return  g.isVolatileHost || g.isSlave
 }
 
 func (g *Guest) GetJSONObjectDesc() (*desc.SGuestDesc, error) {
@@ -242,6 +244,7 @@ func (g *Guest) LoadDesc() error {
 			g.NICs = append(g.NICs[:i], g.NICs[i+1:]...)
 		}
 	}
+	g.isVolatileHost = desc.IsVolatileHost
 	if !desc.IsMaster && desc.IsSlave {
 		g.isSlave = true
 	} else {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
check guest running host is volatile host
**是否需要 backport 到之前的 release 分支**:
NONE
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
