### PR TITLE
Automated cherry pick of #326: fix: vpc metadata server queue size zero

### DIFF
--- a/pkg/agent/server/ovn-md.go
+++ b/pkg/agent/server/ovn-md.go
@@ -132,8 +132,9 @@ func (s *ovnMdServer) Start(ctx context.Context) {
 		}
 		dbAccess := false
 		s.app = app.InitApp(&common_options.BaseOptions{
-			ApplicationID:      fmt.Sprintf("metadata-server-4-subnet-%s", s.netId),
-			RequestWorkerCount: 1,
+			ApplicationID:          fmt.Sprintf("metadata-server-4-subnet-%s", s.netId),
+			RequestWorkerCount:     4,
+			RequestWorkerQueueSize: 128,
 		}, dbAccess)
 		metadata.Start(s.app, svc)
 


### PR DESCRIPTION
Cherry pick of #326 on release/4.0.0.

#326: fix: vpc metadata server queue size zero